### PR TITLE
Parser fixes

### DIFF
--- a/HamsterML/.ocamlinit
+++ b/HamsterML/.ocamlinit
@@ -4,13 +4,13 @@ open HamsterML__Ast;;
 open HamsterML__Lexer;;
 open HamsterML__Parser;;
 open HamsterML__Typing;;
-let parse (s : string) : expr =
+let parse (s : string) : expr list =
   let lexbuf = Lexing.from_string s in
   let ast = HamsterML__Parser.prog HamsterML__Lexer.read lexbuf in
   ast
 ;;
 
-let typecheck (s : string) = 
+(* let typecheck (s : string) = 
   match infer (parse s) with
     | Ok (_, t) -> t
-    | Error e -> failwith (show_error e);;
+    | Error e -> failwith (show_error e);; *)

--- a/HamsterML/lib/parsing/ast.ml
+++ b/HamsterML/lib/parsing/ast.ml
@@ -17,7 +17,7 @@ type paramType =
   | PBool
   | PChar
   | PString
-  | Poly of string (* (a: `a) (b: `b) *)
+  (* | Poly of string (a: `a) (b: `b) *)
 [@@deriving show]
 
 type bop =
@@ -47,7 +47,7 @@ type pattern =
   | Tuple of pattern list (* (1, 2, 3) *)
   | List of pattern list (* [1; 2; 3] *)
   | ListConcat of pattern * pattern (* a :: [b;c]*)
-  | UnitPattern
+  (* | UnitPattern *)
 [@@deriving show]
 
 type expr =

--- a/HamsterML/lib/parsing/ast.ml
+++ b/HamsterML/lib/parsing/ast.ml
@@ -54,7 +54,8 @@ type expr =
   | UnOp of uop * expr
   | Application of expr * expr
   | Value of value
-  | Let of funType * id * value list * expr (* let id a = a *)
+  (* let id a = a | the first `value` is the pattern that can be used instead of function's name *)
+  | Let of funType * value * value list * expr
   | LetUnit of expr (* let () = print_endline "123" *)
   | LetAndIn of expr list * expr option (* let a = 1 and b = 2 in a + b *)
   | Fun of value list * expr (* (fun a -> a + 1) *)

--- a/HamsterML/lib/parsing/ast.ml
+++ b/HamsterML/lib/parsing/ast.ml
@@ -38,29 +38,29 @@ type bop =
 
 type uop = NOT (** not true *) [@@deriving show]
 
-(* Value is a value (dataType -> dataStructure) *)
-type value =
+(* Pattern is a value (dataType -> dataStructure) *)
+type pattern =
   | Const of dataType
   | VarId of id
   | TypedVarID of id * paramType (* (a: int) *)
   | Wildcard (* _ *)
-  | Tuple of value list (* (1, 2, 3) *)
-  | List of value list (* [1; 2; 3] *)
-  | ListConcat of value * value (* a :: [b;c]*)
+  | Tuple of pattern list (* (1, 2, 3) *)
+  | List of pattern list (* [1; 2; 3] *)
+  | ListConcat of pattern * pattern (* a :: [b;c]*)
+  | UnitPattern
 [@@deriving show]
 
 type expr =
   | BinOp of bop * expr * expr
   | UnOp of uop * expr
   | Application of expr * expr
-  | Value of value
-  (* let id a = a | the first `value` is the pattern that can be used instead of function's name *)
-  | Let of funType * value * value list * expr
-  | LetUnit of expr (* let () = print_endline "123" *)
+  | Pattern of pattern
+  (* let id a = a | the first `pattern` is the pattern that can be used instead of function's name *)
+  | Let of funType * pattern * pattern list * expr
   | LetAndIn of expr list * expr option (* let a = 1 and b = 2 in a + b *)
-  | Fun of value list * expr (* (fun a -> a + 1) *)
+  | Fun of pattern list * expr (* (fun a -> a + 1) *)
   | If of expr * expr * expr option (* if a = b then c (else d) *)
-  | Match of expr * (value * expr) list
+  | Match of expr * (pattern * expr) list
 [@@deriving show]
 
 and funType =

--- a/HamsterML/lib/parsing/parser.mly
+++ b/HamsterML/lib/parsing/parser.mly
@@ -145,7 +145,7 @@ float:
     | BOOL                  { PBool }
     | CHAR                  { PChar }
     | STRING                { PString }
-    | n = POLYMORPHIC_NAME  { Poly n }
+    // | n = POLYMORPHIC_NAME  { Poly n }
 
 %inline bop:
     | PLUS                  { ADD }                 
@@ -166,12 +166,13 @@ float:
     | NOT { NOT }
 
 %inline func_id: 
-    | id = IDENTIFIER     { VarId ( id ) }
+    // | id = IDENTIFIER     { VarId ( id ) }
     | op = OP_IDENTIFIER  { VarId ( String.make 1 op ) }
-    (* let _ = .. *)
-    | WILDCARD            { Wildcard }
-    (* let f x = let (k, j) = x in j in f (1, 2) *)
-    | p = pattern         { p }
+    // (* let _ = .. *)
+    // | WILDCARD            { Wildcard }
+    // (* let f x = let (k, j) = x in j in f (1, 2) *)
+    // | p = pattern         { p }
+    | v = value            { v }
 
 const_or_var: (* Const or variable *)
     | const = dataType      {Const const} 
@@ -190,7 +191,7 @@ typed_var: typedVarId = IDENTIFIER; COLON; varType = paramType {TypedVarID (type
 
 %inline let_def:
     (* () = print_endline "123" *)
-    | TYPE_UNIT; EQUAL; e = expr    { Let(Nonrecursive, UnitPattern, [], e)}
+    | TYPE_UNIT; EQUAL; e = expr    { Let(Nonrecursive, Const(Unit), [], e)}
     (* [rec] f x = x *)
     | rec_opt = rec_flag; fun_name = func_id; args = list(value); EQUAL; e = expr   { Let(rec_opt, fun_name, args, e) }
 

--- a/HamsterML/lib/parsing/parser.mly
+++ b/HamsterML/lib/parsing/parser.mly
@@ -98,7 +98,7 @@ declaration :
 
 expr:
     | LEFT_PARENTHESIS; e = expr; RIGHT_PARENTHESIS                     { e }
-    | v = value                                                         { Value v }
+    | v = value                                                         { Pattern v }
     | uop = uop; e = expr                                               { UnOp (uop, e) }
     | le = expr; bop = bop; re = expr                                   { BinOp (bop, le, re) }
     | MATCH; expr = expr; WITH; match_cases = nonempty_list(match_case) { Match (expr, match_cases) }
@@ -124,8 +124,8 @@ value:
     | p = pattern                                       { p }
 
 pattern:
-    | tpl = tuple_dt                                        {Tuple tpl} (* (1, 2, 3, ...) *)
-    | lst = list_dt                                         {List lst}  (* [1; 2; 3; ...] *)
+    | tpl = tuple_dt                                        { Tuple tpl } (* (1, 2, 3, ...) *)
+    | lst = list_dt                                         { List lst }  (* [1; 2; 3; ...] *)
     | lv = const_or_var; DOUBLE_COLON; rv = const_or_var    { ListConcat (lv, rv) } (* hd :: tl *)
     | v = const_or_var ; DOUBLE_COLON; l = list_dt          { ListConcat (v, List l) } (* 1 :: [2; 3] *)
 
@@ -190,7 +190,7 @@ typed_var: typedVarId = IDENTIFIER; COLON; varType = paramType {TypedVarID (type
 
 %inline let_def:
     (* () = print_endline "123" *)
-    | TYPE_UNIT; EQUAL; e = expr                                                    { LetUnit (e) }                     
+    | TYPE_UNIT; EQUAL; e = expr    { Let(Nonrecursive, UnitPattern, [], e)}
     (* [rec] f x = x *)
     | rec_opt = rec_flag; fun_name = func_id; args = list(value); EQUAL; e = expr   { Let(rec_opt, fun_name, args, e) }
 

--- a/HamsterML/lib/typing/typing.ml
+++ b/HamsterML/lib/typing/typing.ml
@@ -327,9 +327,11 @@ module Infer = struct
     | Unit -> return (Subst.empty, TUnit)
   ;;
 
-  let rec infer_args (env : TypeEnv.t) (vs : Ast.value list) : (TypeEnv.t * inf_type) R.t =
+  let rec infer_args (env : TypeEnv.t) (vs : Ast.pattern list)
+    : (TypeEnv.t * inf_type) R.t
+    =
     (* infer value type in fun/let args *)
-    let infer_arg (env : TypeEnv.t) (v : Ast.value) : (TypeEnv.t * inf_type) R.t =
+    let infer_arg (env : TypeEnv.t) (v : Ast.pattern) : (TypeEnv.t * inf_type) R.t =
       match v with
       | Const Unit -> R.return (env, TUnit)
       | Wildcard ->
@@ -348,7 +350,6 @@ module Infer = struct
           | PBool -> TBool
           | PChar -> TChar
           | PString -> TString
-          | Poly _ -> failwith "REMOVE POLY!!!!!!!!"
         in
         let env = TypeEnv.extend name (Scheme.create v_t) env in
         R.return (env, v_t)

--- a/HamsterML/lib/typing/typing.ml
+++ b/HamsterML/lib/typing/typing.ml
@@ -345,7 +345,7 @@ module Infer = struct
            let* ur = Subst.unify tr TString in
            let* res = Subst.compose_all [ sl; sr; ul; ur ] in
            return (res, TString))
-      | Value v ->
+      | Pattern v ->
         (match v with
          | Const dt -> infer_data_type dt
          | _ -> failwith "error in 'value' inference")

--- a/HamsterML/test/parserTest.ml
+++ b/HamsterML/test/parserTest.ml
@@ -367,3 +367,40 @@ let%test _ =
         , BinOp (SUB, Pattern (VarId "x"), Pattern (VarId "y")) )
     ]
 ;;
+
+(* Patterns in functions' names *)
+
+let%test _ =
+  parse "let f x = let (k, j) = x in j in f (1, 2)"
+  = [ LetAndIn
+        ( [ Let
+              ( Nonrecursive
+              , VarId "f"
+              , [ VarId "x" ]
+              , LetAndIn
+                  ( [ Let
+                        ( Nonrecursive
+                        , Tuple [ VarId "k"; VarId "j" ]
+                        , []
+                        , Pattern (VarId "x") )
+                    ]
+                  , Some (Pattern (VarId "j")) ) )
+          ]
+        , Some
+            (Application
+               (Pattern (VarId "f"), Pattern (Tuple [ Const (Int 1); Const (Int 2) ]))) )
+    ]
+;;
+
+let%test _ =
+  parse "let (a,b) = (1,2) in b"
+  = [ LetAndIn
+        ( [ Let
+              ( Nonrecursive
+              , Tuple [ VarId "a"; VarId "b" ]
+              , []
+              , Pattern (Tuple [ Const (Int 1); Const (Int 2) ]) )
+          ]
+        , Some (Pattern (VarId "b")) )
+    ]
+;;

--- a/HamsterML/test/parserTest.ml
+++ b/HamsterML/test/parserTest.ml
@@ -1,204 +1,369 @@
 open HamsterML.Ast
 
-let parse (s : string) : expr =
+let parse (s : string) : expr list =
   let lexbuf = Lexing.from_string s in
   let ast = HamsterML.Parser.prog HamsterML.Lexer.read lexbuf in
   ast
 ;;
 
 (* Data Type tests *)
-let%test _ = parse "+228" = parse "228"
-let%test _ = parse "228" = Value (Const (Int 228))
-let%test _ = parse "-228" = Value (Const (Int (-228)))
-let%test _ = parse "-228.337" = Value (Const (Float (-228.337)))
-let%test _ = parse "+228.337" = Value (Const (Float 228.337))
-let%test _ = parse "228.337" = Value (Const (Float 228.337))
-let%test _ = parse "true" = Value (Const (Bool true))
-let%test _ = parse "false" = Value (Const (Bool false))
-let%test _ = parse "'1'" = Value (Const (Char '1'))
-let%test _ = parse "\"Nike pro\"" = Value (Const (String "Nike pro"))
+let%test _ = parse "let a = +228" = parse "let a = 228"
 
-(* Values *)
+let%test _ =
+  parse "let a = 228" = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Int 228))) ]
+;;
+
+let%test _ =
+  parse "let a = -228"
+  = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Int (-228)))) ]
+;;
+
+let%test _ =
+  parse "let a = -228.337"
+  = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Float (-228.337)))) ]
+;;
+
+let%test _ =
+  parse "let a = +228.337"
+  = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Float 228.337))) ]
+;;
+
+let%test _ =
+  parse "let a = 228.337"
+  = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Float 228.337))) ]
+;;
+
+let%test _ =
+  parse "let a = true"
+  = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Bool true))) ]
+;;
+
+let%test _ =
+  parse "let a = false"
+  = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Bool false))) ]
+;;
+
+let%test _ =
+  parse "let b = '1'" = [ Let (Nonrecursive, VarId "b", [], Pattern (Const (Char '1'))) ]
+;;
+
+let%test _ =
+  parse "let a = \"Nike pro\""
+  = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (String "Nike pro"))) ]
+;;
+
 (* Variables *)
-let%test _ = parse "sigma_nike_pro_228" = Value (VarId "sigma_nike_pro_228")
-let%test _ = parse "pick_me:int" = Value (TypedVarID ("pick_me", PInt))
-let%test _ = parse "sigma : float" = Value (TypedVarID ("sigma", PFloat))
-let%test _ = parse "kfc_boss: string" = Value (TypedVarID ("kfc_boss", PString))
-let%test _ = parse "roblox : char" = Value (TypedVarID ("roblox", PChar))
-let%test _ = parse "( roblox : bool )" = Value (TypedVarID ("roblox", PBool))
-let%test _ = parse "( roblox : `a )" = Value (TypedVarID ("roblox", Poly "a"))
-let%test _ = parse "( roblox : `a )" = Value (TypedVarID ("roblox", Poly "a"))
+let%test _ =
+  parse "let sigma_nike_pro_228 = a"
+  = [ Let (Nonrecursive, VarId "sigma_nike_pro_228", [], Pattern (VarId "a")) ]
+;;
+
+let%test _ =
+  parse "let (pick_me:int) = 1"
+  = [ Let (Nonrecursive, TypedVarID ("pick_me", PInt), [], Pattern (Const (Int 1))) ]
+;;
+
+let%test _ =
+  parse "let sigma : float = 1.2"
+  = [ Let (Nonrecursive, TypedVarID ("sigma", PFloat), [], Pattern (Const (Float 1.2))) ]
+;;
+
+let%test _ =
+  parse "let kfc_boss: string = \"kfc_boss\""
+  = [ Let
+        ( Nonrecursive
+        , TypedVarID ("kfc_boss", PString)
+        , []
+        , Pattern (Const (String "kfc_boss")) )
+    ]
+;;
+
+let%test _ =
+  parse "let roblox : char = 'r'"
+  = [ Let (Nonrecursive, TypedVarID ("roblox", PChar), [], Pattern (Const (Char 'r'))) ]
+;;
+
+let%test _ =
+  parse "let ( roblox : bool ) = false"
+  = [ Let (Nonrecursive, TypedVarID ("roblox", PBool), [], Pattern (Const (Bool false))) ]
+;;
+
+(*
+   let%test _ = parse "( roblox : `a )" = [ Pattern (TypedVarID ("roblox", Poly "a")) ]
+let%test _ = parse "( roblox : `a )" = [ Pattern (TypedVarID ("roblox", Poly "a")) ] *)
 
 (* Patterns *)
 let%test _ =
-  parse "[1; 2; 3; 4]"
-  = Value (List [ Const (Int 1); Const (Int 2); Const (Int 3); Const (Int 4) ])
+  parse "let l = [1; 2; 3; 4]"
+  = [ Let
+        ( Nonrecursive
+        , VarId "l"
+        , []
+        , Pattern (List [ Const (Int 1); Const (Int 2); Const (Int 3); Const (Int 4) ]) )
+    ]
 ;;
 
-let%test _ = parse "[]" = Value (List [])
+let%test _ = parse "let l = []" = [ Let (Nonrecursive, VarId "l", [], Pattern (List [])) ]
 
 let%test _ =
-  parse "1::[2; 3; 4]"
-  = Value
-      (ListConcat (Const (Int 1), List [ Const (Int 2); Const (Int 3); Const (Int 4) ]))
+  parse "let l = 1::[2; 3; 4]"
+  = [ Let
+        ( Nonrecursive
+        , VarId "l"
+        , []
+        , Pattern
+            (ListConcat
+               (Const (Int 1), List [ Const (Int 2); Const (Int 3); Const (Int 4) ])) )
+    ]
 ;;
 
 let%test _ =
-  parse "('a', 'b', 'c', 'd')"
-  = Value
-      (Tuple [ Const (Char 'a'); Const (Char 'b'); Const (Char 'c'); Const (Char 'd') ])
+  parse "let t = ('a', 'b', 'c', 'd')"
+  = [ Let
+        ( Nonrecursive
+        , VarId "t"
+        , []
+        , Pattern
+            (Tuple
+               [ Const (Char 'a'); Const (Char 'b'); Const (Char 'c'); Const (Char 'd') ])
+        )
+    ]
 ;;
 
-let%test _ = parse "( )" = Value (Const Unit)
-let%test _ = parse "( )" = parse "()"
-let%test _ = parse "(_)" = Value Wildcard
+let%test _ =
+  parse "let ( ) = ()" = [ Let (Nonrecursive, Const Unit, [], Pattern (Const Unit)) ]
+;;
+
+let%test _ = parse "let ( ) = ()" = parse "let () = ( )"
+
+let%test _ =
+  parse "let (_) = 1" = [ Let (Nonrecursive, Wildcard, [], Pattern (Const (Int 1))) ]
+;;
 
 (* Expr *)
 (* bop *)
-let%test _ = parse "1 + 2" = BinOp (ADD, Value (Const (Int 1)), Value (Const (Int 2)))
-let%test _ = parse "1 - 2" = BinOp (SUB, Value (Const (Int 1)), Value (Const (Int 2)))
-
 let%test _ =
-  parse "1 + 2 - -3"
-  = BinOp
-      ( SUB
-      , BinOp (ADD, Value (Const (Int 1)), Value (Const (Int 2)))
-      , Value (Const (Int (-3))) )
+  parse "let a = 1 + 2"
+  = [ Let
+        ( Nonrecursive
+        , VarId "a"
+        , []
+        , BinOp (ADD, Pattern (Const (Int 1)), Pattern (Const (Int 2))) )
+    ]
 ;;
 
 let%test _ =
-  parse "1 + (2 - 3)"
-  = BinOp
-      ( ADD
-      , Value (Const (Int 1))
-      , BinOp (SUB, Value (Const (Int 2)), Value (Const (Int 3))) )
+  parse "let b = 1 - 2"
+  = [ Let
+        ( Nonrecursive
+        , VarId "b"
+        , []
+        , BinOp (SUB, Pattern (Const (Int 1)), Pattern (Const (Int 2))) )
+    ]
+;;
+
+let%test _ =
+  parse "let a = 1 + 2 - -3"
+  = [ Let
+        ( Nonrecursive
+        , VarId "a"
+        , []
+        , BinOp
+            ( SUB
+            , BinOp (ADD, Pattern (Const (Int 1)), Pattern (Const (Int 2)))
+            , Pattern (Const (Int (-3))) ) )
+    ]
+;;
+
+let%test _ =
+  parse "let a = 1 + (2 - 3)"
+  = [ Let
+        ( Nonrecursive
+        , VarId "a"
+        , []
+        , BinOp
+            ( ADD
+            , Pattern (Const (Int 1))
+            , BinOp (SUB, Pattern (Const (Int 2)), Pattern (Const (Int 3))) ) )
+    ]
 ;;
 
 (* uop *)
-let%test _ = parse "not true" = UnOp (NOT, Value (Const (Bool true)))
+let%test _ =
+  parse "let a = not true"
+  = [ Let (Nonrecursive, VarId "a", [], UnOp (NOT, Pattern (Const (Bool true)))) ]
+;;
 
 (* fun *)
 let%test _ =
-  parse "fun x y z -> true"
-  = Fun ([ VarId "x"; VarId "y"; VarId "z" ], Value (Const (Bool true)))
+  parse "let f x y z = fun x y z -> true"
+  = [ Let
+        ( Nonrecursive
+        , VarId "f"
+        , [ VarId "x"; VarId "y"; VarId "z" ]
+        , Fun ([ VarId "x"; VarId "y"; VarId "z" ], Pattern (Const (Bool true))) )
+    ]
 ;;
 
 (* if *)
 let%test _ =
-  parse "if x = y then \"nike_pro\" else \"sigma\""
-  = If
-      ( BinOp (EQ, Value (VarId "x"), Value (VarId "y"))
-      , Value (Const (String "nike_pro"))
-      , Some (Value (Const (String "sigma"))) )
+  parse "let f x y = if x = y then \"nike_pro\" else \"sigma\""
+  = [ Let
+        ( Nonrecursive
+        , VarId "f"
+        , [ VarId "x"; VarId "y" ]
+        , If
+            ( BinOp (EQ, Pattern (VarId "x"), Pattern (VarId "y"))
+            , Pattern (Const (String "nike_pro"))
+            , Some (Pattern (Const (String "sigma"))) ) )
+    ]
 ;;
 
 let%test _ =
-  parse "if x = y then \"nike_pro\""
-  = If
-      ( BinOp (EQ, Value (VarId "x"), Value (VarId "y"))
-      , Value (Const (String "nike_pro"))
-      , None )
+  parse "let f x y = if x = y then \"nike_pro\""
+  = [ Let
+        ( Nonrecursive
+        , VarId "f"
+        , [ VarId "x"; VarId "y" ]
+        , If
+            ( BinOp (EQ, Pattern (VarId "x"), Pattern (VarId "y"))
+            , Pattern (Const (String "nike_pro"))
+            , None ) )
+    ]
 ;;
 
 (* match *)
 let%test _ =
-  parse "match rofl with \n  | 228 -> true\n  | 337 -> true\n  | _ -> false"
-  = Match
-      ( Value (VarId "rofl")
-      , [ Const (Int 228), Value (Const (Bool true))
-        ; Const (Int 337), Value (Const (Bool true))
-        ; Wildcard, Value (Const (Bool false))
-        ] )
+  parse "let f rofl = match rofl with\n | 228 -> true\n | 337 -> true\n | _ -> false"
+  = [ Let
+        ( Nonrecursive
+        , VarId "f"
+        , [ VarId "rofl" ]
+        , Match
+            ( Pattern (VarId "rofl")
+            , [ Const (Int 228), Pattern (Const (Bool true))
+              ; Const (Int 337), Pattern (Const (Bool true))
+              ; Wildcard, Pattern (Const (Bool false))
+              ] ) )
+    ]
 ;;
 
 let%test _ =
-  parse "match rofl with \n  | [] -> 0\n  | hd::tl -> 10"
-  = Match
-      ( Value (VarId "rofl")
-      , [ List [], Value (Const (Int 0))
-        ; ListConcat (VarId "hd", VarId "tl"), Value (Const (Int 10))
-        ] )
+  parse "let f rofl = match rofl with \n  | [] -> 0\n  | hd::tl -> 10"
+  = [ Let
+        ( Nonrecursive
+        , VarId "f"
+        , [ VarId "rofl" ]
+        , Match
+            ( Pattern (VarId "rofl")
+            , [ List [], Pattern (Const (Int 0))
+              ; ListConcat (VarId "hd", VarId "tl"), Pattern (Const (Int 10))
+              ] ) )
+    ]
 ;;
 
 (* let *)
-let%test _ = parse "let a = 1" = Let (Nonrecursive, "a", [], Value (Const (Int 1)))
+let%test _ =
+  parse "let a = 1" = [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Int 1))) ]
+;;
 
 let%test _ =
   parse "let rec f a b = true"
-  = Let (Recursive, "f", [ VarId "a"; VarId "b" ], Value (Const (Bool true)))
+  = [ Let (Recursive, VarId "f", [ VarId "a"; VarId "b" ], Pattern (Const (Bool true))) ]
 ;;
 
 let%test _ =
   parse "let f a b = 10 and g c d = 20 and e = 30 in nike_pro"
-  = LetAndIn
-      ( [ Let (Nonrecursive, "f", [ VarId "a"; VarId "b" ], Value (Const (Int 10)))
-        ; Let (Nonrecursive, "g", [ VarId "c"; VarId "d" ], Value (Const (Int 20)))
-        ; Let (Nonrecursive, "e", [], Value (Const (Int 30)))
-        ]
-      , Some (Value (VarId "nike_pro")) )
+  = [ LetAndIn
+        ( [ Let
+              (Nonrecursive, VarId "f", [ VarId "a"; VarId "b" ], Pattern (Const (Int 10)))
+          ; Let
+              (Nonrecursive, VarId "g", [ VarId "c"; VarId "d" ], Pattern (Const (Int 20)))
+          ; Let (Nonrecursive, VarId "e", [], Pattern (Const (Int 30)))
+          ]
+        , Some (Pattern (VarId "nike_pro")) )
+    ]
 ;;
 
 let%test _ =
   parse "let a = 10 and b = 20 in let c = 30 in nike_pro"
-  = LetAndIn
-      ( [ Let (Nonrecursive, "a", [], Value (Const (Int 10)))
-        ; Let (Nonrecursive, "b", [], Value (Const (Int 20)))
-        ]
-      , Some
-          (LetAndIn
-             ( [ Let (Nonrecursive, "c", [], Value (Const (Int 30))) ]
-             , Some (Value (VarId "nike_pro")) )) )
+  = [ LetAndIn
+        ( [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Int 10)))
+          ; Let (Nonrecursive, VarId "b", [], Pattern (Const (Int 20)))
+          ]
+        , Some
+            (LetAndIn
+               ( [ Let (Nonrecursive, VarId "c", [], Pattern (Const (Int 30))) ]
+               , Some (Pattern (VarId "nike_pro")) )) )
+    ]
 ;;
 
 let%test _ =
   parse "let a = 10 and b = 20"
-  = LetAndIn
-      ( [ Let (Nonrecursive, "a", [], Value (Const (Int 10)))
-        ; Let (Nonrecursive, "b", [], Value (Const (Int 20)))
-        ]
-      , None )
+  = [ LetAndIn
+        ( [ Let (Nonrecursive, VarId "a", [], Pattern (Const (Int 10)))
+          ; Let (Nonrecursive, VarId "b", [], Pattern (Const (Int 20)))
+          ]
+        , None )
+    ]
 ;;
 
 (* application *)
 
 let%test _ =
-  parse "(*123*) f x y (*123*)"
-  = Application (Value (VarId "f"), Application (Value (VarId "x"), Value (VarId "y")))
+  parse "let a = (*123*) f x y (*123*)"
+  = [ Let
+        ( Nonrecursive
+        , VarId "a"
+        , []
+        , Application
+            (Pattern (VarId "f"), Application (Pattern (VarId "x"), Pattern (VarId "y")))
+        )
+    ]
 ;;
 
 (* nested recursive let and *)
 
 let%test _ =
   parse "let rec a = 10 and b = 20 in let c = 30 in sigma"
-  = LetAndIn
-      ( [ Let (Recursive, "a", [], Value (Const (Int 10)))
-        ; Let (Nonrecursive, "b", [], Value (Const (Int 20)))
-        ]
-      , Some
-          (LetAndIn
-             ( [ Let (Nonrecursive, "c", [], Value (Const (Int 30))) ]
-             , Some (Value (VarId "sigma")) )) )
+  = [ LetAndIn
+        ( [ Let (Recursive, VarId "a", [], Pattern (Const (Int 10)))
+          ; Let (Nonrecursive, VarId "b", [], Pattern (Const (Int 20)))
+          ]
+        , Some
+            (LetAndIn
+               ( [ Let (Nonrecursive, VarId "c", [], Pattern (Const (Int 30))) ]
+               , Some (Pattern (VarId "sigma")) )) )
+    ]
 ;;
 
 (* Unit *)
-let%test _ = parse "let () = ()" = LetUnit (Value (Const Unit))
+let%test _ =
+  parse "let () = ()" = [ Let (Nonrecursive, Const Unit, [], Pattern (Const Unit)) ]
+;;
 
 let%test _ =
   parse "let () = () and () = print_int 1"
-  = LetAndIn
-      ( [ LetUnit (Value (Const Unit))
-        ; LetUnit (Application (Value (VarId "print_int"), Value (Const (Int 1))))
-        ]
-      , None )
+  = [ LetAndIn
+        ( [ Let (Nonrecursive, Const Unit, [], Pattern (Const Unit))
+          ; Let
+              ( Nonrecursive
+              , Const Unit
+              , []
+              , Application (Pattern (VarId "print_int"), Pattern (Const (Int 1))) )
+          ]
+        , None )
+    ]
 ;;
 
 (* Operation override *)
 
 let%test _ =
   parse "let ( + ) x y = x - y"
-  = Let
-      ( Nonrecursive
-      , "+"
-      , [ VarId "x"; VarId "y" ]
-      , BinOp (SUB, Value (VarId "x"), Value (VarId "y")) )
+  = [ Let
+        ( Nonrecursive
+        , VarId "+"
+        , [ VarId "x"; VarId "y" ]
+        , BinOp (SUB, Pattern (VarId "x"), Pattern (VarId "y")) )
+    ]
 ;;

--- a/HamsterML/test/typingTest.ml
+++ b/HamsterML/test/typingTest.ml
@@ -7,18 +7,23 @@ let typecheck expr =
 ;;
 
 (* data types *)
-let%test _ = typecheck (Value (Const (Int 228))) = TInt
-let%test _ = typecheck (Value (Const (Float 228.337))) = TFloat
-let%test _ = typecheck (Value (Const (String "kfc boss"))) = TString
-let%test _ = typecheck (Value (Const (Bool true))) = TBool
-let%test _ = typecheck (Value (Const (Char '1'))) = TChar
+let%test _ = typecheck (Pattern (Const (Int 228))) = TInt
+let%test _ = typecheck (Pattern (Const (Float 228.337))) = TFloat
+let%test _ = typecheck (Pattern (Const (String "kfc boss"))) = TString
+let%test _ = typecheck (Pattern (Const (Bool true))) = TBool
+let%test _ = typecheck (Pattern (Const (Char '1'))) = TChar
 
 (* binary operations *)
-let%test _ = typecheck (BinOp (ADD, Value (Const (Int 1)), Value (Const (Int 1)))) = TInt
+let%test _ =
+  typecheck (BinOp (ADD, Pattern (Const (Int 1)), Pattern (Const (Int 1)))) = TInt
+;;
 
 let%test _ =
-  typecheck (BinOp (CONCAT, Value (Const (String "nike")), Value (Const (String "pro"))))
+  typecheck
+    (BinOp (CONCAT, Pattern (Const (String "nike")), Pattern (Const (String "pro"))))
   = TString
 ;;
 
-let%test _ = typecheck (BinOp (EQ, Value (Const (Int 1)), Value (Const (Int 20)))) = TBool
+let%test _ =
+  typecheck (BinOp (EQ, Pattern (Const (Int 1)), Pattern (Const (Int 20)))) = TBool
+;;

--- a/HamsterML/test/typingTest.ml
+++ b/HamsterML/test/typingTest.ml
@@ -24,7 +24,9 @@ let%test _ =
   = TString
 ;;
 
-let%test _ = typecheck (BinOp (EQ, Value (Const (Int 1)), Value (Const (Int 20)))) = TBool
+let%test _ =
+  typecheck (BinOp (EQ, Pattern (Const (Int 1)), Pattern (Const (Int 20)))) = TBool
+;;
 
 (* fun *)
 
@@ -32,8 +34,10 @@ let%test _ =
   typecheck
     (Fun
        ( [ VarId "x"; Const Unit; VarId "y"; Const Unit; VarId "z"; Const Unit ]
-       , BinOp (ADD, BinOp (ADD, Value (VarId "x"), Value (VarId "y")), Value (VarId "z"))
-       ))
+       , BinOp
+           ( ADD
+           , BinOp (ADD, Pattern (VarId "x"), Pattern (VarId "y"))
+           , Pattern (VarId "z") ) ))
   = TArrow
       ( TInt
       , TArrow (TUnit, TArrow (TInt, TArrow (TUnit, TArrow (TInt, TArrow (TUnit, TInt)))))


### PR DESCRIPTION
- Now able to parse patterns in functions' names
- `let () ...` and `let ...` constructions unified